### PR TITLE
Fix broken worlds

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,6 +7,20 @@ body {
     overflow: hidden;
 }
 
+/* Hidden class utility */
+.hidden {
+    display: none !important;
+}
+
+/* Game canvas */
+#gameCanvas {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
 /* Customization Screen */
 .customization-screen {
     position: fixed;
@@ -165,10 +179,12 @@ canvas {
     padding: 10px;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
     box-sizing: border-box;
+    z-index: 100;
 }
 
 /* World selector */
 .world-selector {
+    position: absolute;
     top: 10px;
     left: 10px;
     right: 10px;
@@ -177,6 +193,7 @@ canvas {
     gap: 5px;
     max-width: calc(100% - 20px);
     width: auto;
+    z-index: 200;
 }
 
 .world-btn {

--- a/js/ui.js
+++ b/js/ui.js
@@ -40,6 +40,12 @@ export class UI {
     setupWorldSelector() {
         const worldButtons = document.querySelectorAll('.world-btn');
         
+        if (worldButtons.length === 0) {
+            // Retry if buttons not found yet
+            setTimeout(() => this.setupWorldSelector(), 100);
+            return;
+        }
+        
         worldButtons.forEach(btn => {
             btn.addEventListener('click', (e) => {
                 const world = btn.getAttribute('data-world');


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Resolves "worlds not working" by adding essential CSS for visibility and layering, and a retry mechanism for UI element setup.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The "worlds not working" issue stemmed from a combination of display problems (missing `hidden` class, incorrect canvas styling, UI elements appearing behind the canvas due to lack of `z-index`, and incomplete base positioning for the world selector) and a potential timing issue where the world selector buttons might not be fully rendered when the UI attempts to attach event listeners. These changes ensure UI elements are visible, correctly layered, and interactable.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ff38b6c-6627-4bcd-a18e-0ff2e71ec1d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ff38b6c-6627-4bcd-a18e-0ff2e71ec1d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>