### PR TITLE
Pas stad en cavia gedrag aan

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -27,6 +27,7 @@ body {
     width: 100%;
     height: 100%;
     pointer-events: auto;
+    touch-action: none;
 }
 
 /* Customization Screen */

--- a/index.html
+++ b/index.html
@@ -49,14 +49,13 @@
         <canvas id="gameCanvas"></canvas>
         
         <div class="ui-panel world-selector hidden" id="worldSelector">
-            <button class="world-btn active" data-world="stad">🏙️ Stad</button>
+            <button class="world-btn active" data-world="dierenstad">🏪 Dierenstad</button>
             <button class="world-btn" data-world="natuur">🌲 Natuur</button>
             <button class="world-btn" data-world="strand">🏖️ Strand</button>
             <button class="world-btn" data-world="winter">⛷️ Winter</button>
             <button class="world-btn" data-world="woestijn">🏜️ Woestijn</button>
             <button class="world-btn" data-world="jungle">🌴 Jungle</button>
             <button class="world-btn" data-world="zwembad">🏊 Zwembad</button>
-            <button class="world-btn" data-world="dierenstad">🏪 Dierenstad</button>
         </div>
         
         <div class="ui-panel controls hidden">

--- a/js/config.js
+++ b/js/config.js
@@ -45,4 +45,4 @@ export const WORLDS = {
 };
 
 // Default world
-export const DEFAULT_WORLD = WORLDS.STAD;
+export const DEFAULT_WORLD = WORLDS.DIERENSTAD;

--- a/js/game.js
+++ b/js/game.js
@@ -4,7 +4,7 @@ import { Player } from './player.js';
 import { Camera } from './camera.js';
 import { UI } from './ui.js';
 import { drawWorld } from './worlds.js';
-import { createStadBuildings, createDierenstadBuildings, drawInterior } from './buildings.js';
+import { createDierenstadBuildings, drawInterior } from './buildings.js';
 
 export class Game {
     constructor(canvas, customization = {}) {
@@ -72,14 +72,19 @@ export class Game {
         // Mouse/touch controls
         this.canvas.addEventListener('click', (e) => this.handleClick(e));
         
+        // Touch events for mobile
         this.canvas.addEventListener('touchstart', (e) => {
             e.preventDefault();
             const touch = e.touches[0];
-            const rect = this.canvas.getBoundingClientRect();
             this.handleClick({
                 clientX: touch.clientX,
                 clientY: touch.clientY
             });
+        });
+        
+        // Also handle touchend for better mobile experience
+        this.canvas.addEventListener('touchend', (e) => {
+            e.preventDefault();
         });
         
         // World change event
@@ -100,7 +105,7 @@ export class Game {
             // Check if clicked on a building
             let clickedBuilding = false;
             
-            if (this.currentWorld === WORLDS.STAD || this.currentWorld === WORLDS.DIERENSTAD) {
+            if (this.currentWorld === WORLDS.DIERENSTAD) {
                 for (const building of this.buildings) {
                     if (building.contains && building.contains(worldCoords.x, worldCoords.y)) {
                         // Enter building
@@ -194,7 +199,6 @@ export class Game {
     
     getWorldName(world) {
         const names = {
-            'stad': 'de Stad',
             'natuur': 'de Natuur',
             'strand': 'het Strand',
             'winter': 'de Winter',
@@ -210,9 +214,6 @@ export class Game {
         this.buildings = [];
         
         switch (this.currentWorld) {
-            case WORLDS.STAD:
-                this.buildings = createStadBuildings();
-                break;
             case WORLDS.DIERENSTAD:
                 this.buildings = createDierenstadBuildings();
                 break;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Removes the 'city' world, sets 'animal city' as the default and first option, and fixes guinea pig movement on tap.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The guinea pig movement fix involved adding `touch-action: none` to the canvas to prevent default browser touch behaviors and ensuring `touchend` events are handled for more reliable tap detection.

---
<a href="https://cursor.com/background-agent?bcId=bc-e08a8d61-0c3c-436e-a397-fd5a92293eff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e08a8d61-0c3c-436e-a397-fd5a92293eff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>