### PR TITLE
Fix home environment and swimming mini game

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
         <canvas id="gameCanvas"></canvas>
         
         <div class="ui-panel world-selector hidden" id="worldSelector">
+            <button class="world-btn" data-world="thuis">🏠 Thuis</button>
             <button class="world-btn active" data-world="dierenstad">🏪 Dierenstad</button>
             <button class="world-btn" data-world="natuur">🌲 Natuur</button>
             <button class="world-btn" data-world="strand">🏖️ Strand</button>

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -26,6 +26,17 @@ export function createStadBuildings() {
     ];
 }
 
+export function createZwembadBuildings() {
+    return [
+        {
+            x: 500, y: 400, w: 200, h: 150, 
+            color: '#00CED1', name: 'Duik in het Water!',
+            door: {x: 580, y: 475, w: 40, h: 40},
+            isWaterPool: true  // Special flag to identify this as the water pool
+        }
+    ];
+}
+
 function drawShopInterior(ctx, name) {
     // Draw shop name
     ctx.fillStyle = 'black';

--- a/js/game.js
+++ b/js/game.js
@@ -4,7 +4,7 @@ import { Player } from './player.js';
 import { Camera } from './camera.js';
 import { UI } from './ui.js';
 import { drawWorld } from './worlds.js';
-import { createDierenstadBuildings, drawInterior } from './buildings.js';
+import { createDierenstadBuildings, createZwembadBuildings, drawInterior } from './buildings.js';
 import { AnimalChallenge, drawAnimals, checkAnimalClick } from './animals.js';
 import { Shop } from './shop.js';
 import { HomeInventory } from './home-inventory.js';
@@ -261,6 +261,14 @@ export class Game {
     }
     
     enterBuilding(building) {
+        // Check if this is the water pool in the swimming pool world
+        if (building.isWaterPool) {
+            // Enter underwater mini-game instead of building
+            this.underwaterWorld.enter();
+            this.ui.showNotification('Duik in het water! Verzamel alle wortels!');
+            return;
+        }
+        
         // Always enter the building first
         this.isInside = true;
         this.currentBuilding = building;
@@ -390,6 +398,9 @@ export class Game {
         switch (this.currentWorld) {
             case 'dierenstad':
                 this.buildings = createDierenstadBuildings();
+                break;
+            case 'zwembad':
+                this.buildings = createZwembadBuildings();
                 break;
         }
     }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add 'Thuis' (Home) world button and enable entry to the swimming mini-game.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The swimming mini-game was previously inaccessible; a clickable 'water pool' building is now added to the 'Zwembad' (Swimming Pool) world to trigger it.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c0c78d8-ca57-445f-825f-d40c3a677081">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c0c78d8-ca57-445f-825f-d40c3a677081">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>