### PR TITLE
Disable autocorrect for spelling exercise

### DIFF
--- a/js/animals.js
+++ b/js/animals.js
@@ -149,7 +149,7 @@ export class AnimalChallenge {
         document.getElementById('challengeChoice').classList.add('hidden');
         document.getElementById('challengeTask').classList.remove('hidden');
         document.getElementById('taskDescription').textContent = 'Luister goed en typ het woord dat je hoort:';
-        document.getElementById('taskInput').innerHTML = '<input type="text" id="answerInput" placeholder="Typ hier het woord...">';
+        document.getElementById('taskInput').innerHTML = '<input type="text" id="answerInput" placeholder="Typ hier het woord..." autocorrect="off" autocomplete="off" spellcheck="false">';
         document.getElementById('repeatWord').classList.remove('hidden');
         
         // Pronounce the word


### PR DESCRIPTION
Disable autocorrect, autocomplete, and spellcheck for the spelling exercise input field.

This change was requested by the user to make the spelling challenge more difficult by preventing browser assistance.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7b9e709-85cd-4fae-a64c-aeff2e3fd458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7b9e709-85cd-4fae-a64c-aeff2e3fd458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>