### PR TITLE
Fix count indicator bug

### DIFF
--- a/js/inventory.js
+++ b/js/inventory.js
@@ -167,7 +167,7 @@ export class Inventory {
             itemDiv.innerHTML = `
                 <div class="item-emoji">${item.emoji}</div>
                 <div class="item-name">${item.name}</div>
-                <div class="item-quantity">${item.quantity > 1 ? item.quantity : ''}</div>
+                <div class="item-quantity">${item.quantity}</div>
             `;
             
             itemDiv.addEventListener('click', () => this.selectItem(item));


### PR DESCRIPTION
Display item quantity '1' in the inventory UI to improve clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-6801384f-d69f-4d7b-b94e-8cbf2ddef567">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6801384f-d69f-4d7b-b94e-8cbf2ddef567">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>