### PR TITLE
Scrollable shop images and rounded buy buttons

### DIFF
--- a/js/buildings.js
+++ b/js/buildings.js
@@ -1,6 +1,22 @@
 // Buildings module - handles building creation and interiors
 import { CONFIG } from './config.js';
 
+// Utility function to draw rounded rectangle
+function drawRoundedRect(ctx, x, y, width, height, radius) {
+    ctx.beginPath();
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + width - radius, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+    ctx.lineTo(x + width, y + height - radius);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+    ctx.lineTo(x + radius, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+    ctx.lineTo(x, y + radius);
+    ctx.quadraticCurveTo(x, y, x + radius, y);
+    ctx.closePath();
+    ctx.fill();
+}
+
 export function createStadBuildings() {
     return [
         {
@@ -84,7 +100,7 @@ function drawShopInterior(ctx, name) {
         } else {
             ctx.fillStyle = '#999999';
         }
-        ctx.fillRect(buttonX, buttonY, buttonWidth, buttonHeight);
+        drawRoundedRect(ctx, buttonX, buttonY, buttonWidth, buttonHeight, buttonHeight / 2);
         
         ctx.fillStyle = 'white';
         ctx.font = '14px Nunito, sans-serif';
@@ -315,7 +331,7 @@ function drawGroenteMarkt(ctx) {
         } else {
             ctx.fillStyle = '#999999';
         }
-        ctx.fillRect(buttonX, buttonY, buttonWidth, buttonHeight);
+        drawRoundedRect(ctx, buttonX, buttonY, buttonWidth, buttonHeight, buttonHeight / 2);
         
         ctx.fillStyle = 'white';
         ctx.font = '14px Nunito, sans-serif';
@@ -387,7 +403,7 @@ function drawHooiWinkel(ctx) {
         } else {
             ctx.fillStyle = '#999999';
         }
-        ctx.fillRect(buttonX, buttonY, buttonWidth, buttonHeight);
+        drawRoundedRect(ctx, buttonX, buttonY, buttonWidth, buttonHeight, buttonHeight / 2);
         
         ctx.fillStyle = 'white';
         ctx.font = '14px Nunito, sans-serif';
@@ -450,7 +466,7 @@ function drawSpeeltjesShop(ctx) {
         } else {
             ctx.fillStyle = '#999999';
         }
-        ctx.fillRect(buttonX, buttonY, buttonWidth, buttonHeight);
+        drawRoundedRect(ctx, buttonX, buttonY, buttonWidth, buttonHeight, buttonHeight / 2);
         
         ctx.fillStyle = 'white';
         ctx.font = '14px Nunito, sans-serif';
@@ -513,7 +529,7 @@ function drawCaviaSpa(ctx) {
         } else {
             ctx.fillStyle = '#999999';
         }
-        ctx.fillRect(buttonX, buttonY, buttonWidth, buttonHeight);
+        drawRoundedRect(ctx, buttonX, buttonY, buttonWidth, buttonHeight, buttonHeight / 2);
         
         ctx.fillStyle = 'white';
         ctx.font = '14px Nunito, sans-serif';
@@ -580,7 +596,7 @@ function drawAccessoiresShop(ctx) {
         } else {
             ctx.fillStyle = '#999999';
         }
-        ctx.fillRect(buttonX, buttonY, buttonWidth, buttonHeight);
+        drawRoundedRect(ctx, buttonX, buttonY, buttonWidth, buttonHeight, buttonHeight / 2);
         
         ctx.fillStyle = 'white';
         ctx.font = '14px Nunito, sans-serif';

--- a/js/camera.js
+++ b/js/camera.js
@@ -8,7 +8,7 @@ export class Camera {
         this.y = 0;
     }
 
-    update(player, isInside) {
+    update(player, isInside, currentBuilding = null) {
         if (!isInside) {
             // Follow player with camera
             this.x = Math.max(0, Math.min(
@@ -21,9 +21,29 @@ export class Camera {
                 player.y - this.canvas.height / 2
             ));
         } else {
-            // Reset camera for interior view
-            this.x = 0;
-            this.y = 0;
+            // Check if we're in a shop building
+            const shopBuildings = ['Speelgoedwinkel', 'Groente Markt', 'Hooi Winkel', 'Speeltjes & Meer', 'Cavia Spa', 'Accessoires'];
+            const isShop = currentBuilding && shopBuildings.includes(currentBuilding.name);
+            
+            if (isShop) {
+                // Allow scrolling in shops - follow player with some limits
+                const shopWidth = 800; // Standard shop interior width
+                const shopHeight = 600; // Standard shop interior height
+                
+                this.x = Math.max(0, Math.min(
+                    Math.max(0, shopWidth - this.canvas.width), 
+                    player.x - this.canvas.width / 2
+                ));
+                
+                this.y = Math.max(0, Math.min(
+                    Math.max(0, shopHeight - this.canvas.height), 
+                    player.y - this.canvas.height / 2
+                ));
+            } else {
+                // Reset camera for other interior views
+                this.x = 0;
+                this.y = 0;
+            }
         }
     }
 

--- a/js/game.js
+++ b/js/game.js
@@ -153,7 +153,9 @@ export class Game {
         
         // Check if inside a shop and clicking on a shop item
         if (this.isInside && this.currentBuilding && this.shop.isShopBuilding(this.currentBuilding.name)) {
-            if (this.shop.handleClick(x, y)) {
+            // Convert screen coordinates to world coordinates for shops
+            const worldCoords = this.camera.screenToWorld(x, y);
+            if (this.shop.handleClick(worldCoords.x, worldCoords.y)) {
                 return; // Click was handled by shop
             }
         }
@@ -400,7 +402,7 @@ export class Game {
         }
         
         // Update camera
-        this.camera.update(this.player, this.isInside);
+        this.camera.update(this.player, this.isInside, this.currentBuilding);
         
         // Update home inventory if in home world
         if (this.currentWorld === 'thuis') {
@@ -460,8 +462,19 @@ export class Game {
             this.ctx.restore();
         } else {
             // Draw interior
+            this.ctx.save();
+            
+            // Apply camera transform for shops
+            const shopBuildings = ['Speelgoedwinkel', 'Groente Markt', 'Hooi Winkel', 'Speeltjes & Meer', 'Cavia Spa', 'Accessoires'];
+            const isShop = this.currentBuilding && shopBuildings.includes(this.currentBuilding.name);
+            if (isShop) {
+                this.camera.applyTransform(this.ctx);
+            }
+            
             drawInterior(this.ctx, this.currentBuilding);
             this.player.draw(this.ctx);
+            
+            this.ctx.restore();
         }
     }
 


### PR DESCRIPTION
Enable image scrolling in shops on mobile and give all buy buttons fully rounded corners.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ebb74db-5211-4631-9588-efc3d3bcb2bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ebb74db-5211-4631-9588-efc3d3bcb2bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>