### PR TITLE
Correct living room color to original design

### DIFF
--- a/js/home-inventory.js
+++ b/js/home-inventory.js
@@ -146,13 +146,8 @@ export class HomeInventory {
     }
     
     draw(ctx) {
-        // Draw floor
-        ctx.fillStyle = '#8B4513';
-        ctx.fillRect(0, CONFIG.WORLD_HEIGHT - 100, CONFIG.WORLD_WIDTH, 100);
-        
-        // Draw walls
-        ctx.fillStyle = '#D2691E';
-        ctx.fillRect(0, 0, CONFIG.WORLD_WIDTH, CONFIG.WORLD_HEIGHT - 100);
+        // Don't draw floor and walls here - the living room interior is already drawn in drawThuis()
+        // The home world has its own detailed interior design
         
         // Draw other guinea pigs first (before items so they appear behind)
         this.otherGuineaPigs.forEach(pig => {


### PR DESCRIPTION
Remove redundant floor and wall drawing in `HomeInventory` to fix the living room appearing entirely orange.

The `HomeInventory` class was drawing a solid orange/brown background, which was obscuring the detailed living room interior drawn by the `drawThuis` function. This change ensures the correct living room visuals are displayed without being overwritten.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a513113-a428-48a8-aa1c-19c7c8f3368b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a513113-a428-48a8-aa1c-19c7c8f3368b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>