### PR TITLE
Add minigame start button for purchased bath treatment

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -48,6 +48,12 @@ export class Game {
         this.dragStartX = 0;
         this.dragStartY = 0;
         
+        // Mouse position for hover effects
+        this.mouseX = 0;
+        this.mouseY = 0;
+        
+        // Expose game instance globally for debugging and integration
+        
         // Setup world
         this.setupWorld();
         
@@ -200,6 +206,18 @@ export class Game {
                 }
             }
             
+            // Check if in swimming pool world and clicked on water bath button
+            if (this.currentWorld === 'zwembad' && this.waterBathButton) {
+                if (worldCoords.x >= this.waterBathButton.x && 
+                    worldCoords.x <= this.waterBathButton.x + this.waterBathButton.width &&
+                    worldCoords.y >= this.waterBathButton.y && 
+                    worldCoords.y <= this.waterBathButton.y + this.waterBathButton.height) {
+                    // Start bath minigame
+                    this.startBathMinigame();
+                    return;
+                }
+            }
+            
             // Check if clicked on a building
             let clickedBuilding = false;
             
@@ -265,12 +283,28 @@ export class Game {
     }
     
     handleMouseMove(e) {
-        if (!this.isDragging) return;
-        
         const rect = this.canvas.getBoundingClientRect();
         const screenX = e.clientX - rect.left;
         const screenY = e.clientY - rect.top;
         const worldCoords = this.camera.screenToWorld(screenX, screenY);
+        
+        // Store mouse position for hover effects
+        this.mouseX = e.clientX;
+        this.mouseY = e.clientY;
+        
+        // Check if hovering over water bath button
+        if (this.currentWorld === 'zwembad' && this.waterBathButton && !this.isInside) {
+            if (worldCoords.x >= this.waterBathButton.x && 
+                worldCoords.x <= this.waterBathButton.x + this.waterBathButton.width &&
+                worldCoords.y >= this.waterBathButton.y && 
+                worldCoords.y <= this.waterBathButton.y + this.waterBathButton.height) {
+                this.canvas.style.cursor = 'pointer';
+            } else {
+                this.canvas.style.cursor = 'default';
+            }
+        }
+        
+        if (!this.isDragging) return;
         
         this.homeInventory.handleDragMove(worldCoords.x, worldCoords.y);
     }

--- a/js/worlds.js
+++ b/js/worlds.js
@@ -502,6 +502,60 @@ function drawZwembad(ctx) {
             ctx.fillStyle = '#00FF00';
             ctx.font = 'bold 14px Nunito, sans-serif';
             ctx.fillText('✨ Klaar om te zwemmen! ✨', pool.x + pool.w/2, pool.y + pool.h + 20);
+            
+            // Add "Start Minigame" button
+            const buttonWidth = 150;
+            const buttonHeight = 40;
+            const buttonX = pool.x + pool.w/2 - buttonWidth/2;
+            const buttonY = pool.y + pool.h + 40;
+            
+            // Check if hovering
+            let isHovering = false;
+            if (window.game && window.game.waterBathButton) {
+                const rect = window.game.canvas.getBoundingClientRect();
+                const mouseX = window.game.mouseX || 0;
+                const mouseY = window.game.mouseY || 0;
+                const worldCoords = window.game.camera.screenToWorld(mouseX - rect.left, mouseY - rect.top);
+                
+                isHovering = worldCoords.x >= buttonX && 
+                            worldCoords.x <= buttonX + buttonWidth &&
+                            worldCoords.y >= buttonY && 
+                            worldCoords.y <= buttonY + buttonHeight;
+            }
+            
+            // Button background with hover effect
+            ctx.fillStyle = isHovering ? '#5179F1' : '#4169E1';
+            ctx.fillRect(buttonX, buttonY, buttonWidth, buttonHeight);
+            
+            // Button border
+            ctx.strokeStyle = isHovering ? '#3EA0FF' : '#1E90FF';
+            ctx.lineWidth = isHovering ? 3 : 2;
+            ctx.strokeRect(buttonX, buttonY, buttonWidth, buttonHeight);
+            
+            // Button shadow when hovering
+            if (isHovering) {
+                ctx.shadowColor = 'rgba(30, 144, 255, 0.5)';
+                ctx.shadowBlur = 10;
+                ctx.strokeRect(buttonX, buttonY, buttonWidth, buttonHeight);
+                ctx.shadowBlur = 0;
+            }
+            
+            // Button text
+            ctx.fillStyle = 'white';
+            ctx.font = 'bold 16px Nunito, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText('Start Minigame', pool.x + pool.w/2, buttonY + buttonHeight/2);
+            
+            // Store button coordinates for click detection
+            if (window.game) {
+                window.game.waterBathButton = {
+                    x: buttonX,
+                    y: buttonY,
+                    width: buttonWidth,
+                    height: buttonHeight
+                };
+            }
         } else if (pool.name === 'Water') {
             // Add lock icon if badbehandeling not purchased
             ctx.fillStyle = '#FF0000';


### PR DESCRIPTION
Add 'Start Minigame' button to the water bath in the swimming pool world, visible only after bath treatment purchase.

---
<a href="https://cursor.com/background-agent?bcId=bc-aed25c3e-c796-47b4-90c4-e8d722fd183d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aed25c3e-c796-47b4-90c4-e8d722fd183d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>