### PR TITLE
Update modal close button styling and positioning

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1113,10 +1113,10 @@ body {
 /* Unified Close Button for Modals */
 .modal-close-btn {
     position: absolute;
-    top: 15px;
-    right: 15px;
-    background: #E53E3E;
-    color: white;
+    top: 16px;
+    right: 16px;
+    background: white;
+    color: black;
     border: none;
     border-radius: 50%;
     width: 40px;
@@ -1131,5 +1131,5 @@ body {
 
 .modal-close-btn:hover {
     transform: scale(1.1);
-    background: #C53030;
+    background: #f0f0f0;
 }

--- a/js/animals.js
+++ b/js/animals.js
@@ -108,7 +108,7 @@ export class AnimalChallenge {
                     <button id="submitAnswer" class="submit-btn">Controleer</button>
                     <button id="repeatWord" class="repeat-btn hidden">🔊 Herhaal woord</button>
                 </div>
-                <button class="close-btn" id="closeChallenge">✖</button>
+                <button class="modal-close-btn" id="closeChallenge">✖</button>
                 <div id="feedback" class="feedback hidden"></div>
             </div>
         `;

--- a/js/minigames.js
+++ b/js/minigames.js
@@ -17,7 +17,7 @@ export class Minigames {
                 <h2 id="minigameTitle">Minigame</h2>
                 <div id="minigameArea" class="minigame-area"></div>
                 <div id="minigameScore" class="minigame-score">Score: 0</div>
-                <button class="close-btn" id="closeMinigame">✖</button>
+                <button class="modal-close-btn" id="closeMinigame">✖</button>
             </div>
         `;
         document.body.appendChild(this.minigameModal);


### PR DESCRIPTION
Standardize modal close button styling to white with black cross and 16px spacing across all modals.

---
<a href="https://cursor.com/background-agent?bcId=bc-48e4bd1b-ded6-42b5-9ea2-cb61ae421b20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-48e4bd1b-ded6-42b5-9ea2-cb61ae421b20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>