### PR TITLE
Voeg full screen donkere achtergrond toe aan modals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -465,16 +465,15 @@ body {
 /* Challenge Modal Styles */
 .challenge-modal {
     position: fixed;
-    top: 16px;
-    left: 16px;
-    right: 16px;
-    bottom: 16px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(0, 0, 0, 0.7);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 2000;
-    border-radius: 12px;
 }
 
 .challenge-content {
@@ -649,16 +648,15 @@ body {
 /* Mission Modal Styles */
 .mission-modal {
     position: fixed;
-    top: 16px;
-    left: 16px;
-    right: 16px;
-    bottom: 16px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(0, 0, 0, 0.7);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 2000;
-    border-radius: 12px;
 }
 
 .mission-content {
@@ -742,16 +740,15 @@ body {
 
 .inventory-modal {
     position: fixed;
-    top: 16px;
-    left: 16px;
-    right: 16px;
-    bottom: 16px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(0, 0, 0, 0.7);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 2000;
-    border-radius: 12px;
 }
 
 .inventory-content {
@@ -926,16 +923,15 @@ body {
 /* Minigame Styles */
 .minigame-modal {
     position: fixed;
-    top: 16px;
-    left: 16px;
-    right: 16px;
-    bottom: 16px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(0, 0, 0, 0.7);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 2000;
-    border-radius: 12px;
 }
 
 .minigame-content {
@@ -1086,16 +1082,15 @@ body {
 /* Unified Modal Base Styles */
 .modal-base {
     position: fixed;
-    top: 16px;
-    left: 16px;
-    right: 16px;
-    bottom: 16px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(0, 0, 0, 0.7);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 2000;
-    border-radius: 12px;
 }
 
 .modal-content-base {


### PR DESCRIPTION
<pr_request_template>Add full-screen transparent dark backgrounds to all modals.

The previous modal backgrounds had 16px margins and a border-radius, which resulted in white space around the dark overlay. This PR removes these margins and border-radius to ensure the transparent dark background covers the entire screen from edge to edge, as requested.</pr_request_template>

---
<a href="https://cursor.com/background-agent?bcId=bc-b865c3ad-d791-4085-9ba6-44d890c3bc0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b865c3ad-d791-4085-9ba6-44d890c3bc0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>