### PR TITLE
Pas modal randafstand en behoud achtergrond

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -481,8 +481,8 @@ body {
     border-radius: 20px;
     padding: 30px;
     max-width: 500px;
-    width: calc(100% - 16px);
-    max-height: calc(100% - 16px);
+    width: calc(100% - 32px);
+    max-height: calc(100% - 32px);
     position: relative;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
     animation: modalSlideIn 0.3s ease-out;
@@ -664,8 +664,8 @@ body {
     border-radius: 20px;
     padding: 30px;
     max-width: 400px;
-    width: calc(100% - 16px);
-    max-height: calc(100% - 16px);
+    width: calc(100% - 32px);
+    max-height: calc(100% - 32px);
     position: relative;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
     animation: modalSlideIn 0.3s ease-out;
@@ -755,9 +755,9 @@ body {
     background: white;
     border-radius: 20px;
     padding: 30px;
-    width: calc(100% - 16px);
+    width: calc(100% - 32px);
     max-width: 800px;
-    max-height: calc(100% - 16px);
+    max-height: calc(100% - 32px);
     overflow-y: auto;
     position: relative;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
@@ -938,9 +938,9 @@ body {
     background: white;
     border-radius: 20px;
     padding: 30px;
-    width: calc(100% - 16px);
+    width: calc(100% - 32px);
     max-width: 600px;
-    max-height: calc(100% - 16px);
+    max-height: calc(100% - 32px);
     overflow-y: auto;
     position: relative;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
Adjust modal content containers to have a 16px margin from the phone screen edges.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ca46e32-f5cb-4586-a585-69438d1b2e92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ca46e32-f5cb-4586-a585-69438d1b2e92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>