### PR TITLE
Pas witte kaders in modals aan

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -53,11 +53,12 @@ body {
     background: rgba(255, 255, 255, 0.95);
     border-radius: 20px;
     padding: 20px;
+    margin: 8px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
     text-align: center;
     max-width: 600px;
-    width: 100%;
-    max-height: 90vh;
+    width: calc(100% - 16px);
+    max-height: calc(90vh - 16px);
     overflow-y: auto;
 }
 
@@ -480,9 +481,10 @@ body {
     background: white;
     border-radius: 20px;
     padding: 30px;
+    margin: 8px;
     max-width: 500px;
-    width: calc(100% - 32px);
-    max-height: calc(100% - 32px);
+    width: calc(100% - 48px);
+    max-height: calc(100% - 48px);
     position: relative;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
     animation: modalSlideIn 0.3s ease-out;
@@ -957,9 +959,10 @@ body {
     background: white;
     border-radius: 20px;
     padding: 30px;
-    width: calc(100% - 32px);
+    margin: 8px;
+    width: calc(100% - 48px);
     max-width: 600px;
-    max-height: calc(100% - 32px);
+    max-height: calc(100% - 48px);
     overflow-y: auto;
     position: relative;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
@@ -1169,11 +1172,12 @@ body {
     background: rgba(255, 255, 255, 0.95);
     border-radius: 20px;
     padding: 40px;
+    margin: 8px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
     text-align: center;
     max-width: 700px;
-    width: 100%;
-    max-height: 90vh;
+    width: calc(100% - 16px);
+    max-height: calc(90vh - 16px);
     overflow-y: auto;
 }
 

--- a/js/animals.js
+++ b/js/animals.js
@@ -53,27 +53,35 @@ export const ANIMALS = {
     ]
 };
 
-// Spelling words for group 7 level
-const SPELLING_WORDS = [
-    'bibliotheek', 'gymnasium', 'chocolade', 'politieagent', 'ziekenhuis',
-    'vakantie', 'restaurant', 'computer', 'telefoon', 'televisie',
-    'olifant', 'krokodil', 'giraffe', 'nijlpaard', 'chimpansee',
-    'muziekinstrument', 'vioolspelen', 'pianolessen', 'gitaarakkoord',
-    'wetenschapper', 'laboratorium', 'experiment', 'microscoop',
-    'geschiedenis', 'aardrijkskunde', 'natuurkunde', 'scheikunde',
-    'brandweerauto', 'ambulance', 'helikopter', 'vliegtuig',
-    'zwembad', 'voetbalveld', 'tennisbaan', 'schaatsbaan',
-    'ontbijt', 'middageten', 'avondmaaltijd', 'tussendoortje',
-    'vriendschap', 'eerlijkheid', 'behulpzaam', 'verantwoordelijk',
-    'belangrijk', 'moeilijk', 'makkelijk', 'mogelijk', 'onmogelijk',
-    'gezellig', 'vrolijk', 'verdrietig', 'boos', 'blij',
-    'pannenkoek', 'appelmoes', 'aardappel', 'spaghetti', 'macaroni',
-    'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag',
-    'januari', 'februari', 'augustus', 'september', 'december',
-    'schrijven', 'tekenen', 'rekenen', 'lezen', 'spelen',
-    'Nederland', 'België', 'Duitsland', 'Frankrijk', 'Engeland',
-    'hoofdstad', 'provincie', 'gemeente', 'dorpje', 'wereldstad'
-];
+// Spelling words organized by difficulty level
+const SPELLING_WORDS = {
+    6: [
+        // Groep 6 - Basic words
+        'computer', 'telefoon', 'televisie', 'vakantie', 'zwembad',
+        'olifant', 'giraffe', 'ontbijt', 'gezellig', 'vrolijk',
+        'verdrietig', 'boos', 'blij', 'pannenkoek', 'appelmoes',
+        'aardappel', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag',
+        'zaterdag', 'januari', 'februari', 'schrijven', 'tekenen',
+        'rekenen', 'lezen', 'spelen', 'Nederland', 'België',
+        'makkelijk', 'belangrijk', 'mogelijk'
+    ],
+    7: [
+        // Groep 7 - Intermediate words
+        'bibliotheek', 'chocolade', 'restaurant', 'krokodil', 'nijlpaard',
+        'brandweerauto', 'ambulance', 'helikopter', 'vliegtuig', 'voetbalveld',
+        'tennisbaan', 'schaatsbaan', 'middageten', 'vriendschap', 'eerlijkheid',
+        'behulpzaam', 'moeilijk', 'onmogelijk', 'spaghetti', 'macaroni',
+        'augustus', 'september', 'december', 'Duitsland', 'Frankrijk',
+        'Engeland', 'hoofdstad', 'provincie', 'gemeente', 'dorpje'
+    ],
+    8: [
+        // Groep 8 - Advanced words
+        'gymnasium', 'politieagent', 'ziekenhuis', 'chimpansee', 'muziekinstrument',
+        'vioolspelen', 'pianolessen', 'gitaarakkoord', 'wetenschapper', 'laboratorium',
+        'experiment', 'microscoop', 'geschiedenis', 'aardrijkskunde', 'natuurkunde',
+        'scheikunde', 'avondmaaltijd', 'tussendoortje', 'verantwoordelijk', 'wereldstad'
+    ]
+};
 
 export class AnimalChallenge {
     constructor(game) {
@@ -139,7 +147,23 @@ export class AnimalChallenge {
     }
 
     startSpellingChallenge() {
-        const word = SPELLING_WORDS[Math.floor(Math.random() * SPELLING_WORDS.length)];
+        // Use selected difficulties from game settings
+        const selectedDifficulties = this.game.selectedDifficulties || [6, 7];
+        
+        // Collect all words from selected difficulty levels
+        let availableWords = [];
+        selectedDifficulties.forEach(level => {
+            if (SPELLING_WORDS[level]) {
+                availableWords = availableWords.concat(SPELLING_WORDS[level]);
+            }
+        });
+        
+        // If no words available, use default
+        if (availableWords.length === 0) {
+            availableWords = SPELLING_WORDS[6];
+        }
+        
+        const word = availableWords[Math.floor(Math.random() * availableWords.length)];
         this.currentChallenge = {
             type: 'spelling',
             word: word,
@@ -160,7 +184,9 @@ export class AnimalChallenge {
     }
 
     startMathChallenge() {
-        const table = Math.floor(Math.random() * 10) + 1;
+        // Use selected tables from game settings
+        const selectedTables = this.game.selectedTables || [1, 2, 3, 4, 5];
+        const table = selectedTables[Math.floor(Math.random() * selectedTables.length)];
         const multiplier = Math.floor(Math.random() * 10) + 1;
         const answer = table * multiplier;
 

--- a/js/game.js
+++ b/js/game.js
@@ -17,6 +17,10 @@ export class Game {
         this.canvas = canvas;
         this.ctx = canvas.getContext('2d');
         
+        // Store game settings
+        this.selectedTables = customization.selectedTables || [1, 2, 3, 4, 5];
+        this.selectedDifficulties = customization.selectedDifficulties || [6, 7];
+        
         // Make canvas focusable and give it initial focus
         this.canvas.tabIndex = 1;
         this.canvas.focus();


### PR DESCRIPTION
Add 8px margin to modal content and fix selected multiplication tables and spelling difficulties not being applied.

The math challenge was not using the selected multiplication tables, and the spelling challenge was not filtering words based on the selected difficulty levels. This PR addresses both issues by passing the selected settings to the game challenges.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fd560a1-00ba-4e20-914c-0d79b2a9267f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fd560a1-00ba-4e20-914c-0d79b2a9267f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>