### PR TITLE
Fix backpack selection and button bar display

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -328,13 +328,22 @@ body {
         left: 10px;
         right: 10px;
         max-width: none;
-        justify-content: center;
+        justify-content: flex-start;
         background: rgba(255, 255, 255, 0.95);
+        overflow-x: auto;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        padding: 10px;
+        border-radius: 10px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        flex-wrap: nowrap;
     }
     
     .world-btn {
         font-size: 12px;
         padding: 6px 10px;
+        flex-shrink: 0;
+        white-space: nowrap;
     }
     
     .controls {
@@ -443,6 +452,17 @@ body {
     .controls p {
         font-size: 10px;
         margin: 2px 0;
+    }
+}
+
+/* iPad specific adjustments */
+@media only screen 
+  and (min-device-width: 768px) 
+  and (max-device-width: 1024px) 
+  and (orientation: landscape) {
+    .world-selector {
+        bottom: 20px;
+        max-height: 60px;
     }
 }
 

--- a/js/guinea-pig-missions.js
+++ b/js/guinea-pig-missions.js
@@ -90,9 +90,11 @@ export class GuineaPigMissions {
             closeOnEscape: true
         });
         
-        // Event listener for inventory select button
-        document.getElementById('selectFromInventory').addEventListener('click', () => {
-            this.selectFromInventory();
+        // Event listener for inventory select button using event delegation
+        this.missionModal.addEventListener('click', (e) => {
+            if (e.target && e.target.id === 'selectFromInventory') {
+                this.selectFromInventory();
+            }
         });
     }
 


### PR DESCRIPTION
Fixes "Select from inventory" button functionality and iPad display of the world selector.

The "Select from inventory" button stopped working after the modal was re-opened; this is fixed by using event delegation. The world selector bar overflowed on iPads due to lack of overflow control and wrapping, now addressed with horizontal scrolling and flex properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0c2418b-519f-4eab-aad5-370b32299c17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0c2418b-519f-4eab-aad5-370b32299c17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

