### PR TITLE
Position world buttons higher

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -183,7 +183,7 @@ body {
 /* World selector */
 .world-selector {
     position: absolute;
-    bottom: 10px;
+    bottom: 20px;
     left: 10px;
     right: 10px;
     display: flex;


### PR DESCRIPTION
Adjusts the world selector frame's bottom position to ensure visibility and consistent spacing with other UI elements.

The user reported the world selector frame was no longer visible. This change moves it higher, setting its `bottom` property to `20px` to match the `top` spacing of the backpack button and carrot counter, ensuring it's visible and consistently positioned.

---
<a href="https://cursor.com/background-agent?bcId=bc-dceaadac-a204-45af-8795-f73521f4e2ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dceaadac-a204-45af-8795-f73521f4e2ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

