### PR TITLE
Add extra space below world selection

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -183,7 +183,7 @@ body {
 /* World selector */
 .world-selector {
     position: absolute;
-    bottom: 40px;
+    bottom: 20px;
     left: 10px;
     right: 10px;
     display: flex;
@@ -324,7 +324,7 @@ body {
     .world-selector {
         position: fixed;
         top: auto;
-        bottom: 100px;
+        bottom: 80px;
         left: 10px;
         right: 10px;
         max-width: none;
@@ -441,7 +441,7 @@ body {
     }
     
     .world-selector {
-        bottom: 80px;
+        bottom: 60px;
         padding: 8px;
     }
     

--- a/css/styles.css
+++ b/css/styles.css
@@ -183,7 +183,7 @@ body {
 /* World selector */
 .world-selector {
     position: absolute;
-    bottom: 20px;
+    bottom: 40px;
     left: 10px;
     right: 10px;
     display: flex;
@@ -324,7 +324,7 @@ body {
     .world-selector {
         position: fixed;
         top: auto;
-        bottom: 80px;
+        bottom: 100px;
         left: 10px;
         right: 10px;
         max-width: none;
@@ -441,7 +441,7 @@ body {
     }
     
     .world-selector {
-        bottom: 60px;
+        bottom: 80px;
         padding: 8px;
     }
     
@@ -461,7 +461,7 @@ body {
   and (max-device-width: 1024px) 
   and (orientation: landscape) {
     .world-selector {
-        bottom: 20px;
+        bottom: 40px;
         max-height: 60px;
     }
 }


### PR DESCRIPTION
Increase bottom spacing of the world selection box by 20px.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a75c255-59c7-4188-8065-add8dec25a25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a75c255-59c7-4188-8065-add8dec25a25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

