### PR TITLE
Investigate inventory modal not opening

### DIFF
--- a/js/guinea-pig-missions.js
+++ b/js/guinea-pig-missions.js
@@ -129,29 +129,12 @@ export class GuineaPigMissions {
         // Close mission modal first
         console.log('Closing mission modal...');
         domManager.closeModal('missionModal');
-        
-        // Check modal state after closing
-        console.log('Mission modal closed, checking inventory...');
-        
-        // Small delay to ensure modal is fully closed before opening inventory
-        setTimeout(() => {
-            if (this.game.inventory) {
-                console.log('Opening inventory after delay...');
-                this.game.inventory.openInventory();
-                
-                // Debug check after opening
-                setTimeout(() => {
-                    console.log('Inventory state after opening:', {
-                        isOpen: this.game.inventory.isOpen,
-                        modalClassList: this.game.inventory.inventoryModal?.classList?.toString(),
-                        modalDisplay: window.getComputedStyle(this.game.inventory.inventoryModal).display,
-                        modalVisibility: window.getComputedStyle(this.game.inventory.inventoryModal).visibility
-                    });
-                }, 100);
-            } else {
-                console.error('Inventory not found in game object');
-            }
-        }, 50);  // Small delay to prevent race conditions
+        console.log('Mission modal closed, opening inventory immediately...');
+        if (this.game.inventory) {
+            this.game.inventory.openInventory();
+        } else {
+            console.error('Inventory not found in game object');
+        }
     }
 
     showMissionModal(pig) {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -82,7 +82,8 @@ export class Inventory {
         
         // Add click outside to close
         this.inventoryModal.addEventListener('click', (e) => {
-            if (e.target === this.inventoryModal) {
+            // Prevent immediate close right after opening to avoid tap-through from previous modal
+            if (e.target === this.inventoryModal && !this.justOpened) {
                 this.closeInventory();
             }
         });
@@ -158,6 +159,11 @@ export class Inventory {
     
     openInventory() {
         console.log('openInventory called');
+        // Mark as just opened to debounce backdrop click for a short period
+        this.justOpened = true;
+        setTimeout(() => {
+            this.justOpened = false;
+        }, 150);
         
         // Check if modal exists
         if (!this.inventoryModal) {


### PR DESCRIPTION
Fixes Inventory modal not opening when transitioning from the Mission modal.

The previous implementation had a race condition where the pointer-up event from the "Selecteer uit Rugzak" button would immediately close the newly opened Inventory modal's backdrop. This PR removes the artificial delay between closing the Mission modal and opening the Inventory modal, and adds a debounce mechanism to the Inventory modal's backdrop click handler to prevent it from closing on the same tap gesture that opened it.

---
<a href="https://cursor.com/background-agent?bcId=bc-117bf16e-0236-4ba9-adb7-722f1ee2f9e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-117bf16e-0236-4ba9-adb7-722f1ee2f9e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

