### PR TITLE
Onderzoek waarom missiemodal niet sluit

### DIFF
--- a/MISSION_MODAL_FIX.md
+++ b/MISSION_MODAL_FIX.md
@@ -1,0 +1,52 @@
+# Mission Modal Close Button Fix
+
+## Problem
+The mission modal could not be closed when clicking the close button (✖), causing the game to become blocked.
+
+## Root Cause
+The issue was in the `setupMissionModal()` function in `/workspace/js/guinea-pig-missions.js`. The mission content had an event listener that called `e.stopPropagation()` on ALL click events, including clicks on the close button. This prevented the close button's click event from reaching the DOM manager's close handler.
+
+## Solution
+Modified the click event handler on the mission content to check if the clicked element is the close button. If it is, the event is allowed to propagate normally. If it's any other element, propagation is stopped as intended.
+
+### Code Changes
+In `guinea-pig-missions.js`, line 99-101:
+
+**Before:**
+```javascript
+missionContent.addEventListener('click', (e) => {
+    e.stopPropagation();
+});
+```
+
+**After:**
+```javascript
+missionContent.addEventListener('click', (e) => {
+    // Don't stop propagation if clicking the close button
+    if (!e.target.matches('#closeMission')) {
+        e.stopPropagation();
+    }
+});
+```
+
+### Additional Enhancement
+Also added a click handler on the modal background to close the modal when clicking outside the content area:
+
+```javascript
+this.missionModal.addEventListener('click', (e) => {
+    if (e.target === this.missionModal) {
+        this.closeMissionModal();
+    }
+});
+```
+
+## Testing
+You can test the fix by:
+1. Opening the game
+2. Clicking on a guinea pig with a mission
+3. The mission modal should open
+4. Clicking the ✖ button should now properly close the modal
+5. Clicking outside the modal content (on the dark background) should also close it
+6. The Escape key should still work to close the modal
+
+The game should no longer be blocked when the mission modal is open.

--- a/js/guinea-pig-missions.js
+++ b/js/guinea-pig-missions.js
@@ -94,12 +94,23 @@ export class GuineaPigMissions {
         // We'll add direct listeners when the modal is shown instead
         
         // Prevent clicks inside modal content from closing the modal
+        // BUT allow clicks on the close button to propagate
         const missionContent = this.missionModal.querySelector('.mission-content');
         if (missionContent) {
             missionContent.addEventListener('click', (e) => {
-                e.stopPropagation();
+                // Don't stop propagation if clicking the close button
+                if (!e.target.matches('#closeMission')) {
+                    e.stopPropagation();
+                }
             });
         }
+        
+        // Also add click handler to close modal when clicking outside
+        this.missionModal.addEventListener('click', (e) => {
+            if (e.target === this.missionModal) {
+                this.closeMissionModal();
+            }
+        });
     }
 
     closeMissionModal() {


### PR DESCRIPTION
Fixes mission modal close button not working and adds background click to close, resolving a game-blocking issue.

The close button was previously non-functional due to a `stopPropagation` event listener on the modal content, which prevented its click event from being handled. This change modifies the listener to allow the close button's event to propagate correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e9663be-16f2-47f5-b0fd-6c17593cb651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e9663be-16f2-47f5-b0fd-6c17593cb651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

