### PR TITLE
Show horse meadow world button and fix mobile button layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -330,13 +330,13 @@ body {
         max-width: none;
         justify-content: flex-start;
         background: rgba(255, 255, 255, 0.95);
-        overflow-x: auto;
-        overflow-y: hidden;
+        overflow-x: hidden;
+        overflow-y: auto;
         -webkit-overflow-scrolling: touch;
         padding: 10px;
         border-radius: 10px;
         box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
     }
     
     .world-btn {

--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
             <button class="world-btn" data-world="woestijn">🏜️ Woestijn</button>
             <button class="world-btn" data-world="jungle">🌴 Jungle</button>
             <button class="world-btn" data-world="zwembad">🏊 Zwembad</button>
+            <button class="world-btn" data-world="paarden wei">🐴 Paarden Weide</button>
         </div>
         
         <div class="ui-panel design-panel hidden">


### PR DESCRIPTION
Add "Paarden Weide Wereld" button and ensure world buttons wrap on mobile to prevent horizontal scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-04d0f6e5-ba4a-425f-9a1e-8556cb9f8a78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04d0f6e5-ba4a-425f-9a1e-8556cb9f8a78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

