### PR TITLE
Rename paarden weide to paarden

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
             <button class="world-btn" data-world="woestijn">🏜️ Woestijn</button>
             <button class="world-btn" data-world="jungle">🌴 Jungle</button>
             <button class="world-btn" data-world="zwembad">🏊 Zwembad</button>
-            <button class="world-btn" data-world="paarden wei">🐴 Paarden Weide</button>
+                            <button class="world-btn" data-world="paarden">🐴 Paarden</button>
         </div>
         
         <div class="ui-panel design-panel hidden">

--- a/js/animals.js
+++ b/js/animals.js
@@ -51,7 +51,7 @@ export const ANIMALS = {
         { type: 'koe', name: 'Koe', emoji: '🐄', x: 950, y: 480, color: { body: '#000000', belly: '#FFFFFF' } },
         { type: 'varken', name: 'Varken', emoji: '🐷', x: 1250, y: 480, color: { body: '#FFC0CB', belly: '#FFE4E1' } }
     ],
-    'paarden wei': [
+    'paarden': [
         { type: 'paard', name: 'Thunder', emoji: '🐴', x: 300, y: 480, color: { body: '#2c2c2c', belly: '#696969' }, 
           mission: 'Ik heb honger! Breng me 3 appels alsjeblieft!', missionProgress: 0, missionTarget: 3, missionItem: 'apple' },
         { type: 'paard', name: 'Bella', emoji: '🐴', x: 600, y: 480, color: { body: '#8B4513', belly: '#D2691E' }, 
@@ -175,7 +175,7 @@ export class AnimalChallenge {
     showChallenge(animal) {
         this.currentAnimal = animal;
         
-        // Check if this animal has a mission (like horses in paarden wei)
+        // Check if this animal has a mission (like horses in paarden)
         if (animal.mission) {
             // Show mission modal instead of challenge modal
             this.showMissionModal(animal);

--- a/js/config.js
+++ b/js/config.js
@@ -107,7 +107,7 @@ export const WORLDS = [
     'jungle', 
     'zwembad',
     'dierenstad',
-    'paarden wei',
+    'paarden',
     'thuis'
 ];
 

--- a/js/worlds.js
+++ b/js/worlds.js
@@ -27,8 +27,8 @@ export function drawWorld(ctx, worldType, buildings) {
         case 'dierenstad':
             drawDierenstad(ctx, buildings);
             break;
-        case 'paarden wei':
-            drawPaardenWei(ctx);
+        case 'paarden':
+            drawPaarden(ctx);
             break;
         case 'thuis':
             drawThuis(ctx);
@@ -1042,7 +1042,7 @@ function drawThuis(ctx) {
     // Instructions removed
 }
 
-function drawPaardenWei(ctx) {
+function drawPaarden(ctx) {
     // Sky
     ctx.fillStyle = '#87CEEB';
     ctx.fillRect(0, 0, CONFIG.WORLD_WIDTH, CONFIG.WORLD_HEIGHT);


### PR DESCRIPTION
Rename "Paarden weide" to "Paarden" across the application, including UI, configuration, and code logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2d5ae4a-a7f7-45a3-b12e-55946ddc879d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2d5ae4a-a7f7-45a3-b12e-55946ddc879d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

