### PR TITLE
Fix horse tappability

### DIFF
--- a/HORSE_MISSIONS_FIX.md
+++ b/HORSE_MISSIONS_FIX.md
@@ -1,0 +1,50 @@
+# Horse Missions Fix Summary
+
+## Problem
+The missions for horses (paarden) were not working properly. When clicking on a horse, the mission modal would open but without the "Selecteer uit Rugzak" (Select from Backpack) button, making it impossible to complete missions.
+
+## Root Cause
+The horse missions were using a simplified modal implementation in `animals.js` that didn't have inventory integration, while the guinea pig missions used the more sophisticated `MissionManager` class with full inventory support.
+
+## Solution
+
+### 1. Updated AnimalChallenge class (animals.js)
+- Added import for `MissionManager`
+- Added `missionManager` instance to the `AnimalChallenge` constructor
+- Updated `showMissionModal` to use the `MissionManager` instead of creating its own modal
+- Updated `handleMissionItem` to properly update progress through the `MissionManager`
+
+### 2. Updated Inventory System (inventory.js)
+- Renamed `giveItemToMissionPig` to `giveItemToMissionAnimal` to be more generic
+- Added logic to handle both guinea pig missions and other animal missions
+- The method now checks the current world and calls the appropriate mission completion handler
+
+## How It Works Now
+
+1. Click on a horse with a mission (indicated by the yellow exclamation mark)
+2. The mission modal opens with the "Selecteer uit Rugzak" button
+3. Click the button to open the inventory
+4. Select the required item from inventory
+5. The item is given to the horse and mission progress is updated
+6. When the mission is complete, the player receives carrots as a reward
+7. The horse gets a new random mission
+
+## Files Modified
+
+1. `/workspace/js/animals.js`
+   - Added MissionManager import and instance
+   - Updated showMissionModal and handleMissionItem methods
+
+2. `/workspace/js/inventory.js`
+   - Renamed and updated giveItemToMissionPig to giveItemToMissionAnimal
+   - Added support for different animal types based on current world
+
+## Testing
+
+A test file has been created at `/workspace/test-horse-missions.html` to verify the functionality:
+- Go to the horse world (paarden)
+- Add test items to inventory
+- Click on horses to test missions
+- Verify that the inventory integration works correctly
+
+The horse missions should now work exactly like the guinea pig missions, with full inventory integration and proper progress tracking.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -326,7 +326,7 @@ export class Inventory {
         
         // If there's an active mission, give item to mission pig
         if (this.game.activeMission) {
-            this.giveItemToMissionPig(this.selectedItem);
+            this.giveItemToMissionAnimal(this.selectedItem);
         } else {
             // Check if player is near an animal with a mission
             const nearbyAnimal = this.findNearbyAnimalWithMission();
@@ -388,35 +388,42 @@ export class Inventory {
         this.updateSelectedItemInfo();
     }
     
-    giveItemToMissionPig(item) {
+    giveItemToMissionAnimal(item) {
         const mission = this.game.activeMission;
         if (mission && mission.item === item.id) {
-            const pig = mission.pig;
-            pig.missionProgress++;
+            const animal = mission.pig; // Still called 'pig' in the mission data structure
+            animal.missionProgress++;
             
             // Remove one of the item
             this.removeItem(item.id);
             
-            if (pig.missionProgress >= pig.missionTarget) {
+            if (animal.missionProgress >= animal.missionTarget) {
                 // Mission complete!
                 this.game.ui.showNotification(`Missie voltooid! Je hebt ${GAME_CONFIG.MISSION_REWARD} wortels verdiend! 🎉`);
                 this.game.player.carrots += GAME_CONFIG.MISSION_REWARD;
                 this.game.ui.updateDisplay();
                 
-                // Update mission through guinea pig missions
-                if (this.game.guineaPigMissions) {
-                    this.game.guineaPigMissions.completeMission(pig);
+                // Update mission based on animal type
+                if (this.game.guineaPigMissions && this.game.currentWorld === 'home') {
+                    // Handle guinea pig missions
+                    this.game.guineaPigMissions.completeMission(animal);
+                } else if (this.game.animalChallenge) {
+                    // Handle other animal missions (horses, etc.)
+                    this.game.animalChallenge.updateMissionForAnimal(animal);
+                    this.game.animalChallenge.missionManager.completeMission();
                 }
                 
                 // Close inventory and clear mission
                 this.closeInventory();
                 this.game.activeMission = null;
             } else {
-                this.game.ui.showNotification(`Goed zo! Nog ${pig.missionTarget - pig.missionProgress} ${item.name} te gaan!`);
+                this.game.ui.showNotification(`Goed zo! Nog ${animal.missionTarget - animal.missionProgress} ${item.name} te gaan!`);
                 
-                // Update mission modal if it exists
-                if (this.game.guineaPigMissions) {
+                // Update mission modal based on animal type
+                if (this.game.guineaPigMissions && this.game.currentWorld === 'home') {
                     this.game.guineaPigMissions.updateMissionModal();
+                } else if (this.game.animalChallenge) {
+                    this.game.animalChallenge.missionManager.updateProgress(animal.missionProgress);
                 }
                 
                 // Update inventory display

--- a/test-horse-missions.html
+++ b/test-horse-missions.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Horse Missions</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            background: #87CEEB;
+            margin: 0;
+            padding: 20px;
+            font-family: Arial, sans-serif;
+        }
+        
+        .test-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+        }
+        
+        .status {
+            background: #f0f0f0;
+            padding: 10px;
+            border-radius: 5px;
+            margin: 10px 0;
+            font-family: monospace;
+        }
+        
+        .success { background: #d4edda; color: #155724; }
+        .error { background: #f8d7da; color: #721c24; }
+        .info { background: #d1ecf1; color: #0c5460; }
+        
+        .test-button {
+            background: #4CAF50;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            margin: 5px;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        
+        .test-button:hover {
+            background: #45a049;
+        }
+        
+        .test-button.secondary {
+            background: #2196F3;
+        }
+        
+        .test-button.secondary:hover {
+            background: #0b7dda;
+        }
+        
+        #gameCanvas {
+            border: 2px solid #333;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <h1>🐴 Test: Paarden Missies</h1>
+        <p>Deze pagina test of de missies bij de paarden correct werken met de inventory integratie.</p>
+        
+        <div class="test-section">
+            <h2>Test Stappen:</h2>
+            <ol>
+                <li>Ga naar de Paarden wereld</li>
+                <li>Klik op een paard met een geel uitroepteken (!) om een missie te openen</li>
+                <li>Klik op "Selecteer uit Rugzak" in de missie modal</li>
+                <li>Selecteer het juiste item uit je inventory</li>
+                <li>Controleer of de missie voortgang wordt bijgewerkt</li>
+            </ol>
+        </div>
+        
+        <div class="controls">
+            <button class="test-button" onclick="goToPaardenWorld()">Ga naar Paarden Wereld</button>
+            <button class="test-button secondary" onclick="addTestItems()">Voeg Test Items Toe</button>
+            <button class="test-button secondary" onclick="checkGameState()">Check Game State</button>
+        </div>
+        
+        <div id="status" class="status">Wachten op game initialisatie...</div>
+        
+        <canvas id="gameCanvas" width="1024" height="576"></canvas>
+    </div>
+    
+    <!-- Game Scripts -->
+    <script type="module">
+        import { Game } from './js/game.js';
+        import { ANIMALS } from './js/animals.js';
+        
+        let game;
+        
+        function updateStatus(message, type = 'info') {
+            const status = document.getElementById('status');
+            status.textContent = message;
+            status.className = 'status ' + type;
+            console.log(`[${type.toUpperCase()}] ${message}`);
+        }
+        
+        // Initialize game
+        window.addEventListener('load', () => {
+            try {
+                game = new Game();
+                window.game = game; // Make it globally accessible for testing
+                updateStatus('Game geïnitialiseerd. Klik op "Ga naar Paarden Wereld" om te beginnen.', 'success');
+            } catch (error) {
+                updateStatus('Fout bij initialisatie: ' + error.message, 'error');
+                console.error(error);
+            }
+        });
+        
+        window.goToPaardenWorld = function() {
+            if (!game) {
+                updateStatus('Game is nog niet geïnitialiseerd!', 'error');
+                return;
+            }
+            
+            // Switch to paarden world
+            game.currentWorld = 'paarden';
+            game.camera.x = 0;
+            game.camera.y = 0;
+            
+            // Position player in the world
+            game.player.x = 500;
+            game.player.y = 480;
+            
+            updateStatus('Je bent nu in de Paarden wereld. Klik op een paard met een ! om een missie te starten.', 'success');
+        };
+        
+        window.addTestItems = function() {
+            if (!game) {
+                updateStatus('Game is nog niet geïnitialiseerd!', 'error');
+                return;
+            }
+            
+            // Add test items that horses might need
+            const testItems = [
+                { id: 'apple', name: 'Appel', emoji: '🍎', category: 'food', quantity: 10 },
+                { id: 'carrot', name: 'Wortel', emoji: '🥕', category: 'food', quantity: 10 },
+                { id: 'hay_small', name: 'Klein Hooi', emoji: '🌾', category: 'food', quantity: 5 },
+                { id: 'hay_large', name: 'Groot Hooi', emoji: '🌾', category: 'food', quantity: 3 }
+            ];
+            
+            testItems.forEach(item => {
+                for (let i = 0; i < item.quantity; i++) {
+                    game.inventory.addItem(item);
+                }
+            });
+            
+            updateStatus(`Test items toegevoegd aan inventory. Je hebt nu appels, wortels en hooi.`, 'success');
+        };
+        
+        window.checkGameState = function() {
+            if (!game) {
+                updateStatus('Game is nog niet geïnitialiseerd!', 'error');
+                return;
+            }
+            
+            const horses = ANIMALS['paarden'] || [];
+            const horsesWithMissions = horses.filter(h => h.mission);
+            
+            console.log('Game State:', {
+                currentWorld: game.currentWorld,
+                playerPosition: { x: game.player.x, y: game.player.y },
+                animalChallenge: game.animalChallenge ? 'Loaded' : 'Not loaded',
+                missionManager: game.animalChallenge?.missionManager ? 'Loaded' : 'Not loaded',
+                activeMission: game.activeMission,
+                horses: horses.length,
+                horsesWithMissions: horsesWithMissions.length,
+                inventoryItems: game.inventory.items.length
+            });
+            
+            if (horsesWithMissions.length > 0) {
+                console.log('Horses with missions:', horsesWithMissions.map(h => ({
+                    name: h.name,
+                    mission: h.mission,
+                    progress: `${h.missionProgress}/${h.missionTarget}`,
+                    item: h.missionItem
+                })));
+            }
+            
+            updateStatus(`Check console voor game state details. ${horsesWithMissions.length} paarden met missies gevonden.`, 'info');
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Integrate horse missions with the MissionManager to enable inventory interaction and proper mission completion.

The previous horse mission implementation used a simplified modal that lacked the "Selecteer uit Rugzak" button, preventing players from giving items to horses to complete missions. This PR unifies horse and guinea pig mission handling by leveraging the existing `MissionManager` and generalizing the inventory's item-giving logic to support all animals with missions.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5d19b4f-472f-4045-9aeb-830e92f957f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5d19b4f-472f-4045-9aeb-830e92f957f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

