### PR TITLE
Button not activating after table selection

### DIFF
--- a/js/screen-manager.js
+++ b/js/screen-manager.js
@@ -16,13 +16,28 @@ export class ScreenManager {
         // Enable/disable next button based on selection
         const updateNextButton = () => {
             const checkedBoxes = document.querySelectorAll('.table-checkbox:checked');
-            nextBtn.disabled = checkedBoxes.length === 0;
+            if (nextBtn) nextBtn.disabled = checkedBoxes.length === 0;
         };
         
         // Add event listeners to checkboxes
         checkboxes.forEach(checkbox => {
             checkbox.addEventListener('change', updateNextButton);
+            checkbox.addEventListener('input', updateNextButton);
         });
+        
+        // Also handle label clicks (in case some browsers delay change)
+        if (tablesScreen) {
+            tablesScreen.addEventListener('click', (e) => {
+                const label = e.target.closest('.checkbox-label');
+                if (label) {
+                    // Wait a tick for the checkbox to toggle, then update
+                    setTimeout(updateNextButton, 0);
+                }
+            });
+        }
+        
+        // Initialize state on load
+        updateNextButton();
         
         // Handle next button click
         nextBtn.addEventListener('click', () => {
@@ -47,13 +62,27 @@ export class ScreenManager {
         // Enable/disable next button based on selection
         const updateNextButton = () => {
             const checkedBoxes = document.querySelectorAll('.difficulty-checkbox:checked');
-            nextBtn.disabled = checkedBoxes.length === 0;
+            if (nextBtn) nextBtn.disabled = checkedBoxes.length === 0;
         };
         
         // Add event listeners to checkboxes
         checkboxes.forEach(checkbox => {
             checkbox.addEventListener('change', updateNextButton);
+            checkbox.addEventListener('input', updateNextButton);
         });
+        
+        // Also handle label clicks (in case some browsers delay change)
+        if (difficultyScreen) {
+            difficultyScreen.addEventListener('click', (e) => {
+                const label = e.target.closest('.checkbox-label');
+                if (label) {
+                    setTimeout(updateNextButton, 0);
+                }
+            });
+        }
+        
+        // Initialize state on load
+        updateNextButton();
         
         // Handle next button click
         nextBtn.addEventListener('click', () => {


### PR DESCRIPTION
Fixes the "Next" button not activating after selecting a table or difficulty.

The button's state was not reliably updated on selection and was not initialized on load, leading to it remaining disabled. This PR adds `input` event listeners, handles label clicks with a slight delay, and initializes the button state on screen load.

---
<a href="https://cursor.com/background-agent?bcId=bc-982df2b4-66f7-47c1-bbd3-06175b13ba1e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-982df2b4-66f7-47c1-bbd3-06175b13ba1e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

