### PR TITLE
Check repository status

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -133,7 +133,7 @@ export class Game {
                 });
                 this.handleClick(clickEvent);
             }
-        });
+        }, { passive: false });
         
         // Drag and drop events
         this.canvas.addEventListener('mousedown', (e) => this.handleMouseDown(e));
@@ -150,7 +150,7 @@ export class Game {
                 clientY: touch.clientY
             });
             this.handleMouseDown(mouseEvent);
-        });
+        }, { passive: false });
         
         this.canvas.addEventListener('touchmove', (e) => {
             e.preventDefault();
@@ -161,13 +161,13 @@ export class Game {
                 clientY: touch.clientY
             });
             this.handleMouseMove(mouseEvent);
-        });
+        }, { passive: false });
         
         this.canvas.addEventListener('touchend', (e) => {
             e.preventDefault();
             const mouseEvent = new MouseEvent('mouseup', {});
             this.handleMouseUp(mouseEvent);
-        });
+        }, { passive: false });
         
         // World change event using event system
         eventSystem.on(GameEvents.WORLD_CHANGE, (world) => {

--- a/js/home-inventory.js
+++ b/js/home-inventory.js
@@ -162,20 +162,28 @@ export class HomeInventory {
         const saveData = {
             missions: this.guineaPigMissions.saveProgress()
         };
-        localStorage.setItem('homeInventoryProgress', JSON.stringify(saveData));
+        try {
+            localStorage.setItem('homeInventoryProgress', JSON.stringify(saveData));
+        } catch (err) {
+            console.warn('homeInventoryProgress save failed; storage unavailable:', err);
+        }
     }
     
     loadProgress() {
-        const savedData = localStorage.getItem('homeInventoryProgress');
-        if (savedData) {
-            try {
-                const data = JSON.parse(savedData);
-                if (data.missions) {
-                    this.guineaPigMissions.loadProgress(data.missions);
+        try {
+            const savedData = localStorage.getItem('homeInventoryProgress');
+            if (savedData) {
+                try {
+                    const data = JSON.parse(savedData);
+                    if (data.missions) {
+                        this.guineaPigMissions.loadProgress(data.missions);
+                    }
+                } catch (e) {
+                    console.error('Failed to parse home inventory progress:', e);
                 }
-            } catch (e) {
-                console.error('Failed to load home inventory progress:', e);
             }
+        } catch (err) {
+            console.warn('homeInventoryProgress load failed; storage unavailable:', err);
         }
     }
     

--- a/js/home-item-manager.js
+++ b/js/home-item-manager.js
@@ -697,20 +697,28 @@ export class HomeItemManager {
                 color: item.color
             }))
         };
-        localStorage.setItem('homeItems', JSON.stringify(saveData));
+        try {
+            localStorage.setItem('homeItems', JSON.stringify(saveData));
+        } catch (err) {
+            console.warn('homeItems save failed; storage unavailable:', err);
+        }
     }
 
     loadItems() {
-        const savedData = localStorage.getItem('homeItems');
-        if (savedData) {
-            try {
-                const data = JSON.parse(savedData);
-                if (data.items) {
-                    this.items = data.items;
+        try {
+            const savedData = localStorage.getItem('homeItems');
+            if (savedData) {
+                try {
+                    const data = JSON.parse(savedData);
+                    if (data.items) {
+                        this.items = data.items;
+                    }
+                } catch (e) {
+                    console.error('Failed to parse home items:', e);
                 }
-            } catch (e) {
-                console.error('Failed to load home items:', e);
             }
+        } catch (err) {
+            console.warn('homeItems load failed; storage unavailable:', err);
         }
     }
 }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -469,13 +469,21 @@ export class Inventory {
     }
     
     saveInventory() {
-        localStorage.setItem('guineaPigInventory', JSON.stringify(this.items));
+        try {
+            localStorage.setItem('guineaPigInventory', JSON.stringify(this.items));
+        } catch (err) {
+            console.warn('guineaPigInventory save failed; storage unavailable:', err);
+        }
     }
     
     loadInventory() {
         // Clear inventory on page refresh
         this.items = [];
-        localStorage.removeItem('guineaPigInventory');
+        try {
+            localStorage.removeItem('guineaPigInventory');
+        } catch (err) {
+            console.warn('guineaPigInventory remove failed; storage unavailable:', err);
+        }
     }
     
     resetInventory() {

--- a/js/main.js
+++ b/js/main.js
@@ -24,7 +24,7 @@ document.addEventListener('touchend', function(e) {
         e.preventDefault();
     }
     lastTouchEnd = now;
-}, false);
+}, { passive: false });
 
 // Prevent pinch zoom
 document.addEventListener('touchmove', function(e) {
@@ -99,8 +99,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const gameSettings = ScreenManager.getGameSettings();
             
             // Reset inventory for new game
-            localStorage.removeItem('playerInventory');
-            localStorage.removeItem('animalChallengeProgress');
+            try {
+                localStorage.removeItem('playerInventory');
+                localStorage.removeItem('animalChallengeProgress');
+            } catch (err) {
+                console.warn('localStorage remove failed; storage unavailable:', err);
+            }
             
             // Initialize the game with customization and settings data
             const game = new Game(canvas, {


### PR DESCRIPTION
Fix 'Thuis' world blocking on Safari iOS by making touch listeners non-passive and guarding localStorage access.

The "Thuis" world was blocking on Safari iOS due to two main issues: Safari's default passive touch event listeners were preventing `preventDefault()` from working, which is essential for game interaction, and unhandled `localStorage` access errors in Private Browsing mode were causing crashes during world initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d8a0934-4243-4ab7-8534-f547c29d0f6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d8a0934-4243-4ab7-8534-f547c29d0f6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

