### PR TITLE
Geef cavia’s pootjes

### DIFF
--- a/js/guinea-pig-missions.js
+++ b/js/guinea-pig-missions.js
@@ -161,6 +161,23 @@ export class GuineaPigMissions {
             ctx.ellipse(0, 5, 25, 20, 0, 0, Math.PI * 2);
             ctx.fill();
             
+            // Front paws
+            ctx.fillStyle = pig.color.body;
+            ctx.beginPath();
+            ctx.ellipse(-15, 18, 8, 12, 0, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.beginPath();
+            ctx.ellipse(15, 18, 8, 12, 0, 0, Math.PI * 2);
+            ctx.fill();
+
+            // Back legs (larger)
+            ctx.beginPath();
+            ctx.ellipse(-22, 26, 12, 16, 0, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.beginPath();
+            ctx.ellipse(22, 26, 12, 16, 0, 0, Math.PI * 2);
+            ctx.fill();
+            
             // Draw head
             ctx.fillStyle = pig.color.body;
             ctx.beginPath();


### PR DESCRIPTION
Add front and back paws to guinea pig drawings in the home world.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f89a051-51cc-49b6-b0f0-97632ec3b075">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f89a051-51cc-49b6-b0f0-97632ec3b075">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

