### PR TITLE
Shrink guinea pig home world paws

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -579,7 +579,7 @@ export class Game {
             }
             
             // Draw player
-            this.player.draw(this.ctx);
+            this.player.draw(this.ctx, 0.5, this.currentWorld === 'thuis' ? 0.5 : 1);
             
             this.ctx.restore();
         } else {
@@ -604,7 +604,7 @@ export class Game {
                 this.ctx.stroke();
             }
             
-            this.player.draw(this.ctx);
+            this.player.draw(this.ctx, 0.5, this.currentWorld === 'thuis' ? 0.5 : 1);
             
             this.ctx.restore();
         }

--- a/js/player.js
+++ b/js/player.js
@@ -84,7 +84,7 @@ export class Player {
         }
     }
 
-    draw(ctx, scale = 0.5) {
+    draw(ctx, scale = 0.5, feetScale = 1) {
         ctx.save();
         ctx.translate(this.x, this.y);
         ctx.scale(scale, scale);
@@ -125,10 +125,10 @@ export class Player {
         // Feet
         ctx.fillStyle = this.colors.feet;
         ctx.beginPath();
-        ctx.ellipse(-20, 20, 10, 15, 0, 0, Math.PI * 2);
+        ctx.ellipse(-20, 20, 10 * feetScale, 15 * feetScale, 0, 0, Math.PI * 2);
         ctx.fill();
         ctx.beginPath();
-        ctx.ellipse(20, 20, 10, 15, 0, 0, Math.PI * 2);
+        ctx.ellipse(20, 20, 10 * feetScale, 15 * feetScale, 0, 0, Math.PI * 2);
         ctx.fill();
 
         // Eyes


### PR DESCRIPTION
Reduce guinea pig feet size by half when in the 'thuis' world.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8b7ca5f-a249-472e-93e0-9c23bced0b0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8b7ca5f-a249-472e-93e0-9c23bced0b0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

