### PR TITLE
Fix guinea pig paw sizes in home world

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -579,7 +579,7 @@ export class Game {
             }
             
             // Draw player
-            this.player.draw(this.ctx, 0.5, this.currentWorld === 'thuis' ? 0.5 : 1);
+            this.player.draw(this.ctx, 0.5, 1);
             
             this.ctx.restore();
         } else {
@@ -604,14 +604,14 @@ export class Game {
                 this.ctx.stroke();
             }
             
-            this.player.draw(this.ctx, 0.5, this.currentWorld === 'thuis' ? 0.5 : 1);
+            this.player.draw(this.ctx, 0.5, 1);
             
             this.ctx.restore();
         }
         
         performanceMonitor.endTimer('frame');
     }
-
+    
     gameLoop() {
         this.update();
         this.draw();

--- a/js/guinea-pig-missions.js
+++ b/js/guinea-pig-missions.js
@@ -161,21 +161,22 @@ export class GuineaPigMissions {
             ctx.ellipse(0, 5, 25, 20, 0, 0, Math.PI * 2);
             ctx.fill();
             
+            const feetScale = 0.5;
             // Front paws
             ctx.fillStyle = pig.color.body;
             ctx.beginPath();
-            ctx.ellipse(-15, 18, 8, 12, 0, 0, Math.PI * 2);
+            ctx.ellipse(-15, 18, 8 * feetScale, 12 * feetScale, 0, 0, Math.PI * 2);
             ctx.fill();
             ctx.beginPath();
-            ctx.ellipse(15, 18, 8, 12, 0, 0, Math.PI * 2);
+            ctx.ellipse(15, 18, 8 * feetScale, 12 * feetScale, 0, 0, Math.PI * 2);
             ctx.fill();
 
             // Back legs (larger)
             ctx.beginPath();
-            ctx.ellipse(-22, 26, 12, 16, 0, 0, Math.PI * 2);
+            ctx.ellipse(-22, 26, 12 * feetScale, 16 * feetScale, 0, 0, Math.PI * 2);
             ctx.fill();
             ctx.beginPath();
-            ctx.ellipse(22, 26, 12, 16, 0, 0, Math.PI * 2);
+            ctx.ellipse(22, 26, 12 * feetScale, 16 * feetScale, 0, 0, Math.PI * 2);
             ctx.fill();
             
             // Draw head


### PR DESCRIPTION
Restore player guinea pig's paw size to normal and reduce other guinea pigs' paw size in the home world.

---
<a href="https://cursor.com/background-agent?bcId=bc-334f7cb2-7bb9-4943-94ca-2b167382f204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-334f7cb2-7bb9-4943-94ca-2b167382f204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

