### PR TITLE
Fix home world blocking bug

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -188,34 +188,34 @@ body {
 }
 
 /* World selector */
-.world-selector {
-    position: absolute;
-    bottom: 20px;
-    left: 10px;
-    right: 10px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
-    max-width: calc(100% - 20px);
-    width: auto;
-    z-index: 500;
-    pointer-events: auto;
-}
+ .world-selector {
+     position: absolute;
+     bottom: 20px;
+     left: 10px;
+     right: 10px;
+     display: flex;
+     flex-wrap: wrap;
+     gap: 5px;
+     max-width: calc(100% - 20px);
+     width: auto;
+     z-index: 12000;
+     pointer-events: auto;
+ }
 
 .world-btn {
-    padding: 8px 12px;
-    border: none;
-    border-radius: 15px;
-    cursor: pointer;
-    font-size: 14px;
-    background: #667eea;
-    color: white;
-    transition: background-color 0.3s ease;
-    white-space: nowrap;
-    pointer-events: auto;
-    position: relative;
-    z-index: 501;
-}
+     padding: 8px 12px;
+     border: none;
+     border-radius: 15px;
+     cursor: pointer;
+     font-size: 14px;
+     background: #667eea;
+     color: white;
+     transition: background-color 0.3s ease;
+     white-space: nowrap;
+     pointer-events: auto;
+     position: relative;
+     z-index: 12001;
+ }
 
 .world-btn:hover {
     background: #5a67d8;

--- a/js/game.js
+++ b/js/game.js
@@ -437,6 +437,16 @@ export class Game {
         this.camera.y = 0;
         this.isInside = false;
         this.currentBuilding = null;
+        this.isDragging = false; // reset home drag state
+        this.waterBathButton = null; // clear any cached button from zwembad
+        if (this.canvas) this.canvas.style.cursor = 'default';
+        
+        // Proactively close any open overlays that could block input
+        try { if (this.inventory && this.inventory.isOpen) this.inventory.closeInventory(); } catch (e) { /* noop */ }
+        try { if (this.guineaPigMissions && this.guineaPigMissions.missionManager && this.guineaPigMissions.missionManager.isMissionModalVisible && this.guineaPigMissions.missionManager.isMissionModalVisible()) { this.guineaPigMissions.missionManager.closeModal(); } } catch (e) { /* noop */ }
+        try { if (this.animalChallenge && this.animalChallenge.challengeModal && !this.animalChallenge.challengeModal.classList.contains('hidden')) { this.animalChallenge.closeChallenge(); } } catch (e) { /* noop */ }
+        try { if (this.minigames && this.minigames.activeMinigame) this.minigames.closeMinigame(); } catch (e) { /* noop */ }
+        
         this.setupWorld();
         console.log(`World changed successfully to: ${this.currentWorld}`);
         


### PR DESCRIPTION
Fixes movement blockage and hidden world buttons when entering 'Thuis' world.

Previously, certain modals or overlays (like inventory, missions, minigames) could remain open or have a higher z-index upon world change, capturing input and obscuring the world selection buttons. This PR ensures these overlays are closed and the world selector's z-index is elevated.

---
<a href="https://cursor.com/background-agent?bcId=bc-161c2203-ec53-4b67-a257-3387291fe20f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-161c2203-ec53-4b67-a257-3387291fe20f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

