### PR TITLE
Investigate home world freezing issue

### DIFF
--- a/js/guinea-pig-missions.js
+++ b/js/guinea-pig-missions.js
@@ -136,8 +136,10 @@ export class GuineaPigMissions {
 
     checkGuineaPigClick(x, y) {
         for (const pig of this.otherGuineaPigs) {
-            const distance = Math.sqrt(Math.pow(x - pig.x, 2) + Math.pow(y - pig.y, 2));
-            if (distance < 50) {
+            // Require the player to be reasonably close to the guinea pig to interact
+            const clickDistance = Math.hypot(x - pig.x, y - pig.y);
+            const playerDistance = Math.hypot(this.game.player.x - pig.x, this.game.player.y - pig.y);
+            if (clickDistance < 35 && playerDistance < 150) {
                 this.showMissionModal(pig);
                 return true;
             }


### PR DESCRIPTION
Prevent unintended mission modal openings in the home world to fix movement and world switching.

Previously, clicks intended for movement in the home world were often misinterpreted as clicks on a guinea pig, causing a mission modal to repeatedly open and block player movement and world selection. This change tightens the click detection for guinea pigs, requiring both a smaller click radius and player proximity.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba759050-e4fa-484f-9363-f837539bd045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba759050-e4fa-484f-9363-f837539bd045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

