### PR TITLE
Place modals over button frame

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -50,7 +50,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 23000;
     overflow-y: auto;
     padding: 20px;
     box-sizing: border-box;
@@ -198,11 +198,11 @@ body {
      gap: 5px;
      max-width: calc(100% - 20px);
      width: auto;
-     z-index: 12000;
+     z-index: 12000; /* stays below all modals */
      pointer-events: auto;
  }
-
-.world-btn {
+ 
+ .world-btn {
      padding: 8px 12px;
      border: none;
      border-radius: 15px;
@@ -214,7 +214,7 @@ body {
      white-space: nowrap;
      pointer-events: auto;
      position: relative;
-     z-index: 12001;
+     z-index: 12001; /* stays below all modals */
  }
 
 .world-btn:hover {
@@ -1208,7 +1208,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 23000;
     overflow-y: auto;
     padding: 20px;
     box-sizing: border-box;


### PR DESCRIPTION
Increase z-index of selection and customization screens to ensure they appear above the world selection frame.

---
<a href="https://cursor.com/background-agent?bcId=bc-c55c5aa1-4d25-418b-9123-0a75917723bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c55c5aa1-4d25-418b-9123-0a75917723bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

