### PR TITLE
Investigate cavias scrolling bug on ipad safari

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4,12 +4,17 @@ body {
     background: #87CEEB;
     margin: 0;
     padding: 0;
-    overflow: hidden;
+    overflow: hidden; /* prevent page scroll */
     /* Prevent zooming */
     touch-action: pan-x pan-y;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     user-select: none;
+}
+
+:root {
+    /* Fallback to 100vh; updated dynamically on iOS Safari via JS to visualViewport height */
+    --app-height: 100vh;
 }
 
 /* Hidden class utility */
@@ -21,7 +26,7 @@ body {
 .game-container {
     position: relative;
     width: 100%;
-    height: 100vh;
+    height: var(--app-height);
     /* Prevent zooming */
     touch-action: manipulation;
 }
@@ -32,7 +37,7 @@ body {
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: var(--app-height);
     pointer-events: auto;
     touch-action: none;
     z-index: 1;

--- a/js/game.js
+++ b/js/game.js
@@ -94,8 +94,10 @@ export class Game {
     }
 
     resizeCanvas() {
-        this.canvas.width = window.innerWidth;
-        this.canvas.height = window.innerHeight;
+        const vw = window.innerWidth;
+        const vh = window.visualViewport?.height || window.innerHeight;
+        this.canvas.width = vw;
+        this.canvas.height = vh;
         // Clear background cache when canvas is resized
         clearBackgroundCache();
     }

--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,33 @@ import { ScreenManager } from './screen-manager.js';
 // Initialize the game when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
     console.log('DOM loaded, initializing game...');
-    
+
+    // Stabilize viewport height across iOS Safari chrome show/hide
+    const setAppHeight = () => {
+        const vhPx = Math.floor((window.visualViewport?.height || window.innerHeight));
+        document.documentElement.style.setProperty('--app-height', `${vhPx}px`);
+    };
+    setAppHeight();
+    window.addEventListener('resize', setAppHeight);
+    if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', setAppHeight);
+    }
+
+    // Lock body scroll on iOS Safari to prevent rubber-banding/auto scroll
+    const ua = navigator.userAgent || '';
+    const isIOS = /iP(hone|ad|od)/.test(ua) || (ua.includes('Mac') && 'ontouchend' in document);
+    const isSafari = /Safari\//.test(ua) && !/CriOS|FxiOS|Chrome\//.test(ua);
+    if (isIOS && isSafari) {
+        document.body.style.position = 'fixed';
+        document.body.style.width = '100%';
+        document.body.style.left = '0';
+        document.body.style.top = '0';
+        document.body.style.right = '0';
+        document.body.style.bottom = '0';
+        document.body.style.overflow = 'hidden';
+        document.body.style.height = 'var(--app-height)';
+    }
+
     const canvas = document.getElementById('gameCanvas');
     if (!canvas) {
         console.error('Canvas element not found!');


### PR DESCRIPTION
Fixes auto-scrolling and visual duplication on iPad Safari by stabilizing the viewport height and locking body scroll.

---
<a href="https://cursor.com/background-agent?bcId=bc-f277b985-a0e1-43aa-a6f7-ec3b9f45422d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f277b985-a0e1-43aa-a6f7-ec3b9f45422d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

